### PR TITLE
fix: support new apps index with link to bundle JSON

### DIFF
--- a/step_definitions/dhis2/apps/apps.js
+++ b/step_definitions/dhis2/apps/apps.js
@@ -10,7 +10,7 @@ Given(/^I have a list of installed core apps$/, () => {
 
   const elements = browser.$$('a');
   elements.map(element => {
-    if (element.getText() === 'log out' || element.getText() === 'dhis-web-core-resource') return;
+    if (element.getText() === 'log out' || element.getText() === 'dhis-web-core-resource' || element.getText() === 'Apps Bundle JSON') return;
     listOfApps.push(element.getText());
   });
 


### PR DESCRIPTION
Technically this might work, but it's good to skip the unrelated link.  Related to dhis2/dhis2-core#6111