### PR TITLE
chore: Use jdk11 agent instead of jdk11-node14 [v37]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('pipeline-library') _
 pipeline {
   agent {
-    label "ec2-jdk11-node14"
+    label "ec2-jdk11"
   }
 
   options {


### PR DESCRIPTION
Related to https://github.com/dhis2/e2e-tests/pull/105