### PR TITLE
refactor: Use Instance Manager in e2e pipeline [DEVOPS-152]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
 
               sh "./deploy-dhis2.sh $GROUP_NAME $INSTANCE_NAME"
 
-              sh "$WORKSPACE/scripts/generate-analytics.sh $INSTANCE_URL"
+              sh "$WORKSPACE/scripts/generate-analytics.sh admin:district $INSTANCE_URL"
 
               sh "credentials=system:System123 url=$INSTANCE_URL $WORKSPACE/install_app_hub_apps.sh"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
   environment {
     GIT_URL = 'https://github.com/dhis2/e2e-tests'
     BRANCH_BASED_VERSION = "${env.TAG_NAME ? env.GIT_BRANCH.split('-')[0] : '2.' + env.GIT_BRANCH.replaceAll('v', '')}"
-    DHIS2_VERSION = "${env.GIT_BRANCH == 'DEVOPS-152' ? 'dev' : env.BRANCH_BASED_VERSION}"
-    IMAGE_TAG = "${env.GIT_BRANCH == 'DEVOPS-152' ? 'latest' : env.BRANCH_BASED_VERSION}"
+    DHIS2_VERSION = "${env.GIT_BRANCH == 'master' ? 'dev' : env.BRANCH_BASED_VERSION}"
+    IMAGE_TAG = "${env.GIT_BRANCH == 'master' ? 'latest' : env.BRANCH_BASED_VERSION}"
     IMAGE_REPOSITORY = "${env.TAG_NAME ? 'core' : 'core-dev'}"
     INSTANCE_NAME = "e2e-cy-${env.GIT_BRANCH.replaceAll("\\P{Alnum}", "").toLowerCase()}-$BUILD_NUMBER"
     INSTANCE_DOMAIN = 'https://whoami.im.dev.test.c.dhis2.org'
@@ -28,9 +28,9 @@ pipeline {
     HTTP = 'https --check-status'
   }
 
-//  triggers {
-//    cron(env.GIT_BRANCH.contains('.') ? '' : 'H 6 * * *')
-//  }
+  triggers {
+    cron(env.GIT_BRANCH.contains('.') ? '' : 'H 6 * * *')
+  }
 
   stages {
     stage('Checkout IM scripts') {
@@ -158,7 +158,7 @@ pipeline {
          slackSend(
            color: '#ff0000',
            message: "${prefix}E2E tests initialized from branch $GIT_BRANCH for version - $DHIS2_VERSION failed. Please visit " + env.BUILD_URL + " for more information",
-           channel: '@U01RSD1LPB3'
+           channel: '@Haroon;@Hella'
         )
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 @Library('pipeline-library') _
+
 pipeline {
   agent {
-    label "ec2-jdk11"
+    label 'ec2-jdk11'
   }
 
   options {
@@ -10,71 +11,88 @@ pipeline {
   }
 
   environment {
-    HOME = pwd()
-    VERSION = "dev"
-    INSTANCE_NAME = "${VERSION}_smoke"
-    INSTANCE_DOMAIN = "smoke.dhis2.org"
-    INSTANCE_URL = ""
-    GIT_URL = "https://github.com/dhis2/e2e-tests/"
-    AWX_BOT_CREDENTIALS = credentials('awx-bot-user-credentials')
-    ALLURE_REPORT_DIR_PATH = "./allure"
-    ALLURE_RESULTS_DIR = "reports/allure-results"
-    ALLURE_REPORT_DIR = "allure-report-$VERSION"  
-    JIRA_RELEASE_VERSION_NAME = sh(script: './get_next_version.sh', returnStdout: true)
+    GIT_URL = 'https://github.com/dhis2/e2e-tests'
+    BRANCH_BASED_VERSION = "${env.TAG_NAME ? env.GIT_BRANCH.split('-')[0] : '2.' + env.GIT_BRANCH.replaceAll('v', '')}"
+    DHIS2_VERSION = "${env.GIT_BRANCH == 'DEVOPS-152' ? 'dev' : env.BRANCH_BASED_VERSION}"
+    IMAGE_TAG = "${env.GIT_BRANCH == 'DEVOPS-152' ? 'latest' : env.BRANCH_BASED_VERSION}"
+    IMAGE_REPOSITORY = "${env.TAG_NAME ? 'core' : 'core-dev'}"
+    INSTANCE_NAME = "e2e-cy-${env.GIT_BRANCH.replaceAll("\\P{Alnum}", "").toLowerCase()}-$BUILD_NUMBER"
+    INSTANCE_DOMAIN = 'https://whoami.im.dev.test.c.dhis2.org'
+    INSTANCE_HOST = 'https://api.im.dev.test.c.dhis2.org'
+    INSTANCE_URL = "$INSTANCE_DOMAIN/$INSTANCE_NAME"
+    GROUP_NAME = 'whoami'
+    ALLURE_REPORT_DIR_PATH = 'allure'
+    ALLURE_RESULTS_DIR = 'reports/allure-results'
+    ALLURE_REPORT_DIR = "allure-report-$DHIS2_VERSION"
+    JIRA_RELEASE_VERSION_NAME = "${env.TAG_NAME ? env.DHIS2_VERSION : sh(script: './get_next_version.sh', returnStdout: true)}"
+    HTTP = 'https --check-status'
   }
 
-  triggers {
-    cron(env.BRANCH_NAME.contains('.') ? '' : 'H 6 * * *')
-  }
+//  triggers {
+//    cron(env.GIT_BRANCH.contains('.') ? '' : 'H 6 * * *')
+//  }
 
-  stages {     
-    stage('Configure job') {
-      when {
-        buildingTag()
-      }
-
+  stages {
+    stage('Checkout IM scripts') {
       steps {
         script {
-          VERSION = "${env.BRANCH_NAME}".split("-")[0]
-          INSTANCE_NAME = "${env.BRANCH_NAME}" 
-          INSTANCE_URL = "https://${INSTANCE_DOMAIN}/${INSTANCE_NAME}/"
-          JIRA_RELEASE_VERSION_NAME = "$VERSION"
-          echo "Version: $VERSION, JIRA_RELEASE_VERSION_NAME: $JIRA_RELEASE_VERSION_NAME"
+          dir('im-manager') {
+            checkout([
+              $class: 'GitSCM',
+              branches: [[name: '*/master']],
+              extensions: [[$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: '/scripts']]]],
+              userRemoteConfigs: [[url: 'https://github.com/dhis2-sre/im-manager']]
+            ])
+          }
+
+          dir('im-db-manager') {
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                extensions: [[$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: '/scripts']]]],
+                userRemoteConfigs: [[url: 'https://github.com/dhis2-sre/im-database-manager']]
+            ])
+          }
         }
       }
     }
 
-    stage('Update instance') {
+    stage('Create DHIS2 instance') {
       steps {
         script {
-          INSTANCE_URL = "https://${INSTANCE_DOMAIN}/${INSTANCE_NAME}/"
-          awx.resetWar("$AWX_BOT_CREDENTIALS", "${INSTANCE_DOMAIN}", "${INSTANCE_NAME}")
-          sh "credentials=system:System123 url=${INSTANCE_URL} ./delete-data.sh"
-          sh "credentials=system:System123 url=${INSTANCE_URL} ./install_app_hub_apps.sh"
-        } 
+          withCredentials([usernamePassword(credentialsId: 'e2e-im-user', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
+            dir('im-db-manager/scripts') {
+              env.DATABASE_ID = sh(
+                  returnStdout: true,
+                  script: "./list.sh | jq -r '.[] | select(.Name == \"$GROUP_NAME\") .Databases[] | select(.Name|contains(\"Sierra Leone - $DHIS2_VERSION\")) .ID'"
+              ).trim()
+
+              sh '[ -n "$DATABASE_ID" ]'
+              echo "DATABASE_ID is $DATABASE_ID for version $DHIS2_VERSION"
+            }
+
+            dir('im-manager/scripts') {
+              echo 'Creating DHIS2 instance ...'
+
+              // 1 day
+              env.INSTANCE_TTL = sh(returnStdout: true, script: '#!/usr/bin/env bash\necho \$(($EPOCHSECONDS + 86400))').trim()
+
+              sh "./deploy-dhis2.sh $GROUP_NAME $INSTANCE_NAME"
+
+              sh "$WORKSPACE/scripts/generate-analytics.sh $INSTANCE_URL"
+
+              sh "credentials=system:System123 url=$INSTANCE_URL $WORKSPACE/install_app_hub_apps.sh"
+            }
+          }
+        }
       }
     }
 
     stage('Prepare reports dir') {
       steps {
-        script {
-          if (!fileExists("$ALLURE_REPORT_DIR_PATH")) {
-            sh "mkdir -p $ALLURE_REPORT_DIR_PATH"
-          } 
-          if (fileExists("$ALLURE_RESULTS_DIR")) {
-            dir("$ALLURE_RESULTS_DIR", {
-              deleteDir()
-            })
-          }   
-    
-          sh "mkdir -p ./$ALLURE_RESULTS_DIR"
-              
-          if (fileExists("$ALLURE_REPORT_DIR_PATH/$ALLURE_REPORT_DIR/history")) {
-            sh "cp  -r $ALLURE_REPORT_DIR_PATH/$ALLURE_REPORT_DIR/history ./$ALLURE_RESULTS_DIR/history"
-            sh "cp  -r $ALLURE_REPORT_DIR_PATH/$ALLURE_REPORT_DIR/data ./$ALLURE_RESULTS_DIR/data"
-          } 
-        } 
-      }      
+        sh "mkdir -p $ALLURE_REPORT_DIR_PATH"
+        sh "mkdir -p $ALLURE_RESULTS_DIR"
+      }
     }
 
     stage('Test') {
@@ -82,10 +100,9 @@ pipeline {
         JIRA_ENABLED = false
         JIRA_USERNAME = "$JIRA_USERNAME"
         JIRA_PASSWORD = "$JIRA_PASSWORD"
-        BASE_URL = "${INSTANCE_URL}"
-        CI_BUILD_ID="${BUILD_NUMBER}"
+        BASE_URL = "$INSTANCE_URL"
+        CI_BUILD_ID = "$BUILD_NUMBER"
         RP_TOKEN = credentials('report-portal-access-uuid')
-        JIRA_RELEASE_VERSION_NAME = "$JIRA_RELEASE_VERSION_NAME"
       }
 
       steps {
@@ -93,15 +110,13 @@ pipeline {
           // assign version to the report portal version attribute
           def json = sh(returnStdout: true, script: "jq '.reportportalAgentJsCypressReporterOptions.attributes[0].value=\"${JIRA_RELEASE_VERSION_NAME}\"' reporter-config.json")
           writeFile(text: "$json", file: 'reporter-config.json')
-          sh "docker-compose up --exit-code-from cypress-tests"
-          sh "python3 merge_rp_launches.py"
+          sh 'docker-compose up --exit-code-from cypress-tests'
+          sh 'python3 merge_rp_launches.py'
         }
-        
-       
       }
     }
   }
-    
+
   post {
     always {
       script {
@@ -117,28 +132,33 @@ pipeline {
           reportBuildPolicy: 'ALWAYS',
           results: [[path: "$ALLURE_RESULTS_DIR"]],
           report: "$ALLURE_REPORT_DIR_PATH/$ALLURE_REPORT_DIR"
-          ])  
-        }     
+          ])
+        }
       }
-    
+
     success {
       script {
-        // stop the instance after to offload smoke.dhis2
-        awx.stopWar("$AWX_BOT_CREDENTIALS", "smoke.dhis2.org", "${INSTANCE_NAME}")
+        dir('im-manager/scripts') {
+          withCredentials([usernamePassword(credentialsId: 'e2e-im-user', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
+            echo 'Deleting DHIS2 instance ...'
+
+            sh "./destroy.sh $GROUP_NAME $INSTANCE_NAME"
+          }
+        }
       }
     }
-    
+
     failure {
       script {
         def prefix = ""
         if (fileExists('./reports/new_failures.json')) {
-          prefix = "NEW ERRORS FOUND! "
+          prefix = 'NEW ERRORS FOUND! '
         }
 
          slackSend(
-            color: '#ff0000',
-            message: "${prefix}E2E tests initialized from branch $GIT_BRANCH for version - $VERSION failed. Please visit " + env.BUILD_URL + " for more information",
-            channel: '@Haroon;@Hella'
+           color: '#ff0000',
+           message: "${prefix}E2E tests initialized from branch $GIT_BRANCH for version - $DHIS2_VERSION failed. Please visit " + env.BUILD_URL + " for more information",
+           channel: '@U01RSD1LPB3'
         )
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
 
   environment {
     GIT_URL = 'https://github.com/dhis2/e2e-tests'
-
     BRANCH_BASED_VERSION = "${env.TAG_NAME ? env.GIT_BRANCH.split('-')[0] : '2.' + env.GIT_BRANCH.replaceAll('v', '')}"
     DHIS2_VERSION = "${env.GIT_BRANCH == 'master' ? 'dev' : env.BRANCH_BASED_VERSION}"
     IMAGE_TAG = "${env.GIT_BRANCH == 'master' ? 'latest' : env.BRANCH_BASED_VERSION}"
@@ -28,9 +27,10 @@ pipeline {
     INSTANCE_DOMAIN = "https://${INSTANCE_GROUP_NAME}.im.$INSTANCE_ENVIRONMENT"
     INSTANCE_HOST = "https://api.im.$INSTANCE_ENVIRONMENT"
     INSTANCE_URL = "$INSTANCE_DOMAIN/$INSTANCE_NAME"
+    DHIS2_CREDENTIALS = credentials('dhis2-default')
     ALLURE_REPORT_DIR_PATH = 'allure'
     ALLURE_RESULTS_DIR = 'reports/allure-results'
-    ALLURE_REPORT_DIR = 'allure-report-$DHIS2_VERSION'
+    ALLURE_REPORT_DIR = "allure-report-$DHIS2_VERSION"
     JIRA_RELEASE_VERSION_NAME = "${env.TAG_NAME ? env.DHIS2_VERSION : sh(script: './get_next_version.sh', returnStdout: true)}"
     HTTP = 'https --check-status'
   }
@@ -87,9 +87,9 @@ pipeline {
 
               sh "./deploy-dhis2.sh $INSTANCE_GROUP_NAME $INSTANCE_NAME"
 
-              sh "$WORKSPACE/scripts/generate-analytics.sh admin:district $INSTANCE_URL"
+              sh "$WORKSPACE/scripts/generate-analytics.sh \$DHIS2_CREDENTIALS $INSTANCE_URL"
 
-              sh "credentials=system:System123 url=$INSTANCE_URL $WORKSPACE/install_app_hub_apps.sh"
+              sh "credentials=\$DHIS2_CREDENTIALS url=$INSTANCE_URL $WORKSPACE/install_app_hub_apps.sh"
             }
           }
         }

--- a/scripts/generate-analytics.sh
+++ b/scripts/generate-analytics.sh
@@ -9,11 +9,24 @@ function instance_response() {
   $HTTP --follow --headers get "$instance_url" | head -1 | cut -d ' ' -f 2
 }
 
+function analytics_status() {
+  $HTTP --auth "$dhis2_credentials" get "${instance_url}${analytics_status_endpoint}" |
+  jq -r '.[] .completed'
+}
+
+instance_readiness_threshold=300
 instance_readiness_start_time=$SECONDS
 until [[ "$(instance_response)" == "200" ]]
 do
-  echo "Instance not ready yet, $(($SECONDS-$instance_readiness_start_time))s elapsed ..."
-  sleep 30
+  elapsed_seconds=$(($SECONDS-$instance_readiness_start_time))
+
+  if [[ $elapsed_seconds -gt $instance_readiness_threshold ]]; then
+    echo "Instance didn't get ready in the ${instance_readiness_threshold}s threshold."
+    exit 1
+  fi
+
+  echo "Instance not ready yet, ${elapsed_seconds}s elapsed ..."
+  sleep 10
 done
 echo "Instance is ready! Triggering Analytics generation ..."
 
@@ -23,15 +36,10 @@ analytics_status_endpoint=$(
 )
 echo "Analytics notifier: $analytics_status_endpoint"
 
-function analytics_status() {
-  $HTTP --auth "$dhis2_credentials" get "${instance_url}${analytics_status_endpoint}" |
-  jq -r '.[] .completed'
-}
-
 analytics_tasks_readiness_start_time=$SECONDS
 until [[ "$(analytics_status)" =~ "true" ]]
 do
   echo "Analytics tasks haven't completed yet, $(($SECONDS-$analytics_tasks_readiness_start_time))s elapsed ..."
-  sleep 30
+  sleep 10
 done
 echo "Analytics tasks have completed!"

--- a/scripts/generate-analytics.sh
+++ b/scripts/generate-analytics.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-instance_url="$1"
-
-default_dhis2_credentials="admin:district"
+dhis2_credentials="$1"
+instance_url="$2"
 
 function instance_response() {
   $HTTP --follow --headers get "$instance_url" | head -1 | cut -d ' ' -f 2
@@ -19,13 +18,13 @@ done
 echo "Instance is ready! Triggering Analytics generation ..."
 
 analytics_status_endpoint=$(
-  $HTTP --auth "$default_dhis2_credentials" post "$instance_url/api/resourceTables/analytics" |
+  $HTTP --auth "$dhis2_credentials" post "$instance_url/api/resourceTables/analytics" |
   jq -r '.response .relativeNotifierEndpoint'
 )
 echo "Analytics notifier: $analytics_status_endpoint"
 
 function analytics_status() {
-  $HTTP --auth "$default_dhis2_credentials" get "${instance_url}${analytics_status_endpoint}" |
+  $HTTP --auth "$dhis2_credentials" get "${instance_url}${analytics_status_endpoint}" |
   jq -r '.[] .completed'
 }
 

--- a/scripts/generate-analytics.sh
+++ b/scripts/generate-analytics.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+instance_url="$1"
+
+default_dhis2_credentials="admin:district"
+
+function instance_response() {
+  $HTTP --follow --headers get "$instance_url" | head -1 | cut -d ' ' -f 2
+}
+
+instance_readiness_start_time=$SECONDS
+until [[ "$(instance_response)" == "200" ]]
+do
+  echo "Instance not ready yet, $(($SECONDS-$instance_readiness_start_time))s elapsed ..."
+  sleep 30
+done
+echo "Instance is ready! Triggering Analytics generation ..."
+
+analytics_status_endpoint=$(
+  $HTTP --auth "$default_dhis2_credentials" post "$instance_url/api/resourceTables/analytics" |
+  jq -r '.response .relativeNotifierEndpoint'
+)
+echo "Analytics notifier: $analytics_status_endpoint"
+
+function analytics_status() {
+  $HTTP --auth "$default_dhis2_credentials" get "${instance_url}${analytics_status_endpoint}" |
+  jq -r '.[] .completed'
+}
+
+analytics_tasks_readiness_start_time=$SECONDS
+until [[ "$(analytics_status)" =~ "true" ]]
+do
+  echo "Analytics tasks haven't completed yet, $(($SECONDS-$analytics_tasks_readiness_start_time))s elapsed ..."
+  sleep 30
+done
+echo "Analytics tasks have completed!"


### PR DESCRIPTION
The pipeline will:

- select a DHIS2 version, docker image and repository based on the branch/tag it's run from
- select a DB from the IM DB Manager based on the DHIS2 version
- deploy a DHIS2 instance
- generate analytics
- install the latest Line Listing and Capture apps compatible with the DHIS2 version
- run the E2E (smoke) tests
- generate Allure reports
- destroy the DHIS2 instance regardless of the test results

When triggered manually there's a checkbox parameter to keep the instance alive, which will disable the destroy step at the end.

![image](https://user-images.githubusercontent.com/8098421/201402122-0599ac5c-1ab0-49ee-8fbd-9260d0cbb96f.png)



The changes are tested as if the pipeline was run from both `master` and `v*` branches, as well as a tag like `2.39.0-rc`.