### PR TITLE
ci: run cron only on master or maintenance version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 @Library('pipeline-library') _
 
+boolean isOnMasterOrMaintenanceVersionBranch = env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("v")
+
 pipeline {
   agent {
     label 'ec2-jdk11'
@@ -40,7 +42,7 @@ pipeline {
   }
 
   triggers {
-    cron(env.BRANCH_NAME.contains('.') ? '' : 'H 6 * * 1-5')
+    cron(isOnMasterOrMaintenanceVersionBranch ? 'H 6 * * 1-5' : '')
   }
 
   stages {


### PR DESCRIPTION
I saw that cron is running for any branch including PR branches 
This fix is to run only on master and the supported branches.
