### PR TITLE
fix: fix data_visualizer_app tests

### DIFF
--- a/cypress/utils/analytics.js
+++ b/cypress/utils/analytics.js
@@ -4,7 +4,7 @@ export const EVENT_VISUALIZER_APP_URL = "dhis-web-event-visualizer";
 export const MAPS_APP_URL = "dhis-web-maps"; 
 export const LINE_LISTING_APP = "api/apps/line-listing/index.html";
 export const Selectors = {
-  VISUALIZATION_TITLE: '[data-test="visualization-title"]',
+  VISUALIZATION_TITLE: '[data-test="AO-title"]',
   LOADER: '[data-test="dhis2-uicore-circularloader"]'
 }
 


### PR DESCRIPTION

the selector `data-test="visualization-title"` does not exist in all graphic types

**example1:** it exist here https://smoke.dhis2.org/dev_smoke/dhis-web-data-visualizer/#/SnOdv9tEkaf
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/125370676/228059070-988f9db4-ab65-45fd-9efd-34d87049d581.png">

**example2:** but does not exist for this one https://smoke.dhis2.org/dev_smoke/dhis-web-data-visualizer/#/q60WgmVe96y
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/125370676/228059167-33762b68-3a40-4e1c-831d-f10daa68887b.png">

A quick fix will be to use another selector `data-test="AO-title"` instead of `data-test="visualization-title"` 
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/125370676/228059759-833359db-90ad-47cd-8810-329515c49619.png">

**Before the fix:**

https://ci.dhis2.org/job/e2e-tests/job/master/535/allure/#suites/d282da470e822e83d02415f54ffa2465/19464ac7e35e4baf/
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/125370676/228060178-b58e1ba6-eb8e-4572-a29b-b08b3e72a0d5.png">

**After the fix:**
https://ci.dhis2.org/job/e2e-tests/job/PR-224/1/allure/#suites/7c39aead21403f4b3509f12c29bad5b2
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/125370676/228060767-6c626c8f-49b8-4b3e-b811-f06af2cd3d01.png">

