### PR TITLE
ci: update IM hostname reference after shortening

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,11 @@ pipeline {
     IMAGE_TAG = "${env.TARGET_BRANCH == 'master' ? 'latest' : env.REF_BASED_VERSION}"
     IMAGE_REPOSITORY = "${env.TAG_NAME ? 'core' : 'core-dev'}"
     IM_REPO_URL = 'https://github.com/dhis2-sre/im-manager'
-    IM_ENVIRONMENT = 'prod.test.c.dhis2.org'
-    IM_HOST = "https://api.im.$IM_ENVIRONMENT"
+    IM_ENVIRONMENT = 'im.dhis2.org'
+    IM_HOST = "https://api.$IM_ENVIRONMENT"
     INSTANCE_GROUP_NAME = 'qa'
     INSTANCE_NAME = "e2e-cy-${env.GIT_BRANCH.replaceAll("\\P{Alnum}", "").toLowerCase()}-$BUILD_NUMBER"
-    INSTANCE_DOMAIN = "https://${INSTANCE_GROUP_NAME}.im.$IM_ENVIRONMENT"
+    INSTANCE_DOMAIN = "https://${INSTANCE_GROUP_NAME}.$IM_ENVIRONMENT"
     INSTANCE_URL = "$INSTANCE_DOMAIN/$INSTANCE_NAME"
     INSTANCE_READINESS_THRESHOLD_ENV = "${params.instance_readiness_threshold}"
     INSTANCE_TTL = "${params.keep_instance_alive ? params.keep_instance_alive_for.toInteger() * 60 : ''}"


### PR DESCRIPTION
Related to https://github.com/dhis2-sre/im-manager/pull/417

This PR can be merged after the changes from the PR above are deployed to the prod environment.