### PR TITLE
Push test results to reportportal [v39]

### DIFF
--- a/merge_rp_launches.py
+++ b/merge_rp_launches.py
@@ -1,6 +1,6 @@
 import requests, os, time
 from datetime import datetime
-URL = "https://test.tools.dhis2.org/reportportal/api/v1/dhis2_auto"
+URL = "https://test.reports.dhis2.org/api/v1/dhis2_auto"
 RP_TOKEN = os.getenv('RP_TOKEN')
 CI_BUILD_ID = os.getenv('CI_BUILD_ID')
 LAUNCH_BRANCH_VERSION = os.getenv('LAUNCH_BRANCH_VERSION')

--- a/reporter-config.json
+++ b/reporter-config.json
@@ -6,14 +6,14 @@
     "testCycle": "automated-tests"
   },
   "reportportalAgentJsCypressReporterOptions": {
-    "endpoint": "https://test.tools.dhis2.org/reportportal/api/v1",
+    "endpoint": "https://test.reports.dhis2.org/api/v1",
     "launch": "e2e_tests_master",
     "project": "dhis2_auto",
     "description": "",
     "attributes": [
       {
-          "key": "version",
-          "value": "master"
+        "key": "version",
+        "value": "master"
       }
     ],
     "debug": false,


### PR DESCRIPTION
backport of https://github.com/dhis2/e2e-tests/pull/269