### PR TITLE
ci: disable manual merge reportportal test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
             sh 'docker-compose up --exit-code-from cypress-tests'
           }
 
-          sh 'python3 merge_rp_launches.py'
+          // sh 'python3 merge_rp_launches.py'
         }
       }
     }


### PR DESCRIPTION
Temporary change because of breaking change in the RP API 
The RP service-api container keeps going unhealthy since we migrated to v23.1