### PR TITLE
chore: enhanced error handling in init-data plugin

### DIFF
--- a/cypress/plugins/init-data.js
+++ b/cypress/plugins/init-data.js
@@ -2,29 +2,11 @@ const axios = require('axios');
 const struts_apps = ['dhis-web-dataentry/index.action']
 const queryParams = '?fields=displayName,id&paging=false';
 
-async function install( config ) {
-  console.log('Initializing data')
+async function install(config) {
+  try {
+    console.log('Initializing data');
 
-  const login = await axios.get('/api', {
-    baseURL: config.baseUrl,
-    auth: {
-      username: config.env.LOGIN_USERNAME,
-      password: config.env.LOGIN_PASSWORD,
-    }
-  });
-
-  const client = axios.create({
-    withCredentials: false,
-    timeout: 20000,
-    baseURL: config.baseUrl,
-    headers: {
-      'Cookie': login.headers['set-cookie'][0]
-    }
-  });
-
-  const fetchData = async ( url, callback) => {
-    
-    const { data } = await client.get(url, {
+    const login = await axios.get('/api', {
       baseURL: config.baseUrl,
       auth: {
         username: config.env.LOGIN_USERNAME,
@@ -32,53 +14,97 @@ async function install( config ) {
       }
     });
 
-    return callback( data ); 
-  };
-  
-  await fetchData('/dhis-web-apps/apps-bundle.json', ( data ) => {
-    const appList = struts_apps;
-  
-    appList.push(...data.flatMap(i => i.webName))
-    config.env.apps = appList
-    console.log('APPS: ')
-    console.table(config.env.apps);
-  })
+    const client = axios.create({
+      withCredentials: false,
+      timeout: 20000,
+      baseURL: config.baseUrl,
+      headers: {
+        'Cookie': login.headers['set-cookie'][0]
+      }
+    });
 
-  await fetchData('/api/dashboards' + queryParams, (data) => {
-    config.env.dashboards = data.dashboards;
-    console.log('DASHBOARDS:')
-    console.table(config.env.dashboards);
-  })
+    const fetchData = async (url, callback) => {
+      try {
+        const { data } = await client.get(url, {
+          baseURL: config.baseUrl,
+          auth: {
+            username: config.env.LOGIN_USERNAME,
+            password: config.env.LOGIN_PASSWORD,
+          }
+        });
+        return callback(data);
+      } catch (error) {
+        console.error(`Error fetching data from ${url}:`, error);
+      }
+    };
 
-  await fetchData('/api/visualizations' + queryParams, (data) => {
-    config.env.visualizations = data.visualizations;
-    console.log('VISUALIZATIONS:')
-    console.table(config.env.visualizations);
-  })
+    // Fetch apps
+    await fetchData('/dhis-web-apps/apps-bundle.json', (data) => {
+      if (data) {
+        const appList = struts_apps;
+        appList.push(...data.flatMap(i => i.webName))
+        config.env.apps = appList
+        console.log('APPS: ')
+        console.table(config.env.apps);
+      }
+    });
 
-  await fetchData('/api/eventReports.json' + queryParams, (data) =>{
-    config.env.eventReports = data.eventReports;
-    console.log('EVENT REPORTS:')
-    console.table(config.env.eventReports);
-  })
+    // Fetch dashboards
+    await fetchData('/api/dashboards' + queryParams, (data) => {
+      if (data) {
+        config.env.dashboards = data.dashboards;
+        console.log('DASHBOARDS:')
+        console.table(config.env.dashboards);
+      }
+    });
 
-  await fetchData('/api/eventCharts.json' + queryParams, (data) => {
-    config.env.eventCharts = data.eventCharts;
-    console.log('EVENT CHARTS:')
-    console.table(config.env.eventCharts);
-  })
+    // Fetch visualizations
+    await fetchData('/api/visualizations' + queryParams, (data) => {
+      if (data) {
+        config.env.visualizations = data.visualizations;
+        console.log('VISUALIZATIONS:')
+        console.table(config.env.visualizations);
+      }
+    });
 
-  await fetchData('/api/maps.json' + queryParams, ( data ) => {
-    config.env.maps = data.maps;
-    console.log('MAPS')
-    console.table(config.env.maps);
-  })
+    // Fetch event reports
+    await fetchData('/api/eventReports.json' + queryParams, (data) => {
+      if (data) {
+        config.env.eventReports = data.eventReports;
+        console.log('EVENT REPORTS:')
+        console.table(config.env.eventReports);
+      }
+    });
 
-  await fetchData(`/api/eventVisualizations.json${queryParams}&filter=type:eq:LINE_LIST`, ( data ) => {
-    config.env.eventVisualizations = data.eventVisualizations;
-    console.log('EVENT VISUALIZATIONS: ')
-    console.table(config.env.eventVisualizations);
-  })
+    // Fetch event charts
+    await fetchData('/api/eventCharts.json' + queryParams, (data) => {
+      if (data) {
+        config.env.eventCharts = data.eventCharts;
+        console.log('EVENT CHARTS:')
+        console.table(config.env.eventCharts);
+      }
+    });
+
+    // Fetch maps
+    await fetchData('/api/maps.json' + queryParams, (data) => {
+      if (data) {
+        config.env.maps = data.maps;
+        console.log('MAPS:')
+        console.table(config.env.maps);
+      }
+    });
+
+    // Fetch event visualizations
+    await fetchData(`/api/eventVisualizations.json${queryParams}&filter=type:eq:LINE_LIST`, (data) => {
+      if (data) {
+        config.env.eventVisualizations = data.eventVisualizations;
+        console.log('EVENT VISUALIZATIONS:')
+        console.table(config.env.eventVisualizations);
+      }
+    });
+  } catch (error) {
+    console.error('Error in install function:', error);
+  }
 }
 
-module.exports = {install};
+module.exports = { install };


### PR DESCRIPTION
Adding error handling to the init-data plugin.

this comes in response to resent test failures.


<img width="978" alt="image" src="https://github.com/dhis2/e2e-tests/assets/125370676/3b34bf24-5df7-4c1d-a3b9-cd490fd7e6f0">


errors logs in the Console Output: 

> cypress-tests_1  | Initializing data
> cypress-tests_1  | Your configFile threw an error from: /e2e/cypress.config.js
> cypress-tests_1  | 
> cypress-tests_1  | The error was thrown while executing your e2e.setupNodeEvents() function:
> cypress-tests_1  | 
> cypress-tests_1  | TypeError: data.flatMap is not a function
> cypress-tests_1  |     at /e2e/cypress/plugins/init-data.js:41:26
> cypress-tests_1  |     at fetchData (/e2e/cypress/plugins/init-data.js:35:12)
> cypress-tests_1  |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
> cypress-tests_1  |     at async Object.install (/e2e/cypress/plugins/init-data.js:38:3)
> cypress-tests_1  |     at async module.exports (/e2e/cypress/plugins/index.js:25:3)
> cypress-tests_1  | libva error: vaGetDriverNameByIndex() failed with unknown libva error, driver_name = (null)
> cypress-tests_1  | [1304:0109/065427.929199:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
> cypress-tests_1  | Your configFile threw an error from: /e2e/cypress.config.js
> cypress-tests_1  | 
> cypress-tests_1  | The error was thrown while executing your e2e.setupNodeEvents() function:
> cypress-tests_1  | 
> cypress-tests_1  | TypeError: data.flatMap is not a function
> cypress-tests_1  |     at /e2e/cypress/plugins/init-data.js:41:26
> cypress-tests_1  |     at fetchData (/e2e/cypress/plugins/init-data.js:35:12)
> cypress-tests_1  |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
> cypress-tests_1  |     at async Object.install (/e2e/cypress/plugins/init-data.js:38:3)
> cypress-tests_1  |     at async module.exports (/e2e/cypress/plugins/index.js:25:3)
> cypress-tests_1  | Initializing data
> cypress-tests_1  | Your configFile threw an error from: /e2e/cypress.config.js
> cypress-tests_1  | 
> cypress-tests_1  | The error was thrown while executing your e2e.setupNodeEvents() function:
> cypress-tests_1  | 
> cypress-tests_1  | TypeError: data.flatMap is not a function
> cypress-tests_1  |     at /e2e/cypress/plugins/init-data.js:41:26
> cypress-tests_1  |     at fetchData (/e2e/cypress/plugins/init-data.js:35:12)
> cypress-tests_1  |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
> cypress-tests_1  |     at async Object.install (/e2e/cypress/plugins/init-data.js:38:3)
> cypress-tests_1  |     at async module.exports (/e2e/cypress/plugins/index.js:25:3)
> cypress-tests_1  | node:fs:1392
> cypress-tests_1  |   handleErrorFromBinding(ctx);
> cypress-tests_1  |   ^
> cypress-tests_1  | 
> cypress-tests_1  | Error: ENOENT: no such file or directory, scandir '/e2e/runner-results'
> cypress-tests_1  |     at Object.readdirSync (node:fs:1392:3)
> cypress-tests_1  |     at collectResults (/e2e/node_modules/cypress-parallel/utility.js:35:26)
> cypress-tests_1  |     at start (/e2e/node_modules/cypress-parallel/cli.js:32:23)
> cypress-tests_1  |     at processTicksAndRejections (node:internal/process/task_queues:96:5) {
> cypress-tests_1  |   errno: -2,
> cypress-tests_1  |   syscall: 'scandir',
> cypress-tests_1  |   code: 'ENOENT',
> cypress-tests_1  |   path: '/e2e/runner-results'
> cypress-tests_1  | }
> e2e-tests_v39_cypress-tests_1 exited with code 1
> 1
> Aborting on container exit...

` 