### PR TITLE
chore: skip dashboard tests

### DIFF
--- a/cypress/e2e/dashboards_app.cy.js
+++ b/cypress/e2e/dashboards_app.cy.js
@@ -6,7 +6,7 @@ import {
   openApp,
 } from "../utils/dashboard";
 
-describe(
+describe.skip(
   "Dashboards -> DHIS2-8010",
   {
     tags: ["smoke"],


### PR DESCRIPTION
skip dashboard tests due to performance issues in v40 causing cypress crashes

![image](https://github.com/dhis2/e2e-tests/assets/125370676/ef66e8dd-1c4a-48a8-b99b-acb84e25ed68)
