### PR TITLE
Run all tests serially and in headless mode

### DIFF
--- a/cypress/e2e/dashboards_app.cy.js
+++ b/cypress/e2e/dashboards_app.cy.js
@@ -6,7 +6,7 @@ import {
   openApp,
 } from "../utils/dashboard";
 
-describe.skip(
+describe(
   "Dashboards -> DHIS2-8010",
   {
     tags: ["smoke"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
       - ./allure-report:/e2e/allure-report
       - ./screenshots:/e2e/cypress/screenshots
       - ./env_files:/e2e/env_files
-    entrypoint: "yarn run cy:parallel-report && python3 merge_rp_launches.py"
+    entrypoint: "yarn run cy:test && python3 merge_rp_launches.py"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "DHIS2 E2E testing",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:test": "cypress run --browser chrome",
+    "cy:test": "cypress run --headless --browser chrome",
     "cy:parallel": "cypress-parallel -t 3 -s cy:test -d cypress/e2e",
     "cy:parallel-report": "cypress-parallel -r cypress-multi-reporters -o configFile=reporter-config.json -t 3 -s cy:test -d cypress/e2e",
     "allure": "allure generate --clean ./reports/allure-results/ && allure open",


### PR DESCRIPTION
Run tests serially in Chrome headless to see if it alleviates the memory pressure
this is a workaround against the cypress test crash for dashboard tests 
![image](https://github.com/user-attachments/assets/d39fa251-7b0e-4b3d-a234-e4614f1b8857)
