### PR TITLE
ci: create directory for Docker Compose v2 bind mount

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,6 +184,8 @@ pipeline {
 
       steps {
         script {
+          sh 'mkdir -p $WORKSPACE/screenshots'
+
           unarchive mapping: ['cypress.env.json': 'cypress.env.json']
           // assign version to the report portal version attribute and name the launch based on the branch
           def json = sh(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,6 +185,7 @@ pipeline {
       steps {
         script {
           sh 'mkdir -p $WORKSPACE/screenshots'
+          sh 'mkdir -p $WORKSPACE/allure-report'
 
           unarchive mapping: ['cypress.env.json': 'cypress.env.json']
           // assign version to the report portal version attribute and name the launch based on the branch


### PR DESCRIPTION
This PR fixes an issue with [Docker Compose v2](https://github.com/dhis2/e2e-tests/commit/26103073fbaed6342f34d0efd1588f118cc1090d) where a bind mount fails if the source directory does not exist. 

`Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /home/ubuntu/jenkins-tmp/workspace/e2e-tests_v39/screenshots
`

A step was added to create the necessary directory (`screenshots`) before running the `docker compose` command to ensure the pipeline executes correctly.

